### PR TITLE
imageのタグをdebian指定に修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:8.0
+FROM mysql:8.0-debian
 RUN apt-get update
 RUN apt-get -y install locales-all
 ENV LANG ja_JP.UTF-8


### PR DESCRIPTION
現状だとoracleのイメージが取得され、apt-getできないため。