### PR TITLE
volumeに指定するパスを絶対パスから相対パスに変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,4 +14,4 @@ services:
     ports:
       - 3307:3306
     volumes:
-      - $PWD/sql:/docker-entrypoint-initdb.d
+      - ./sql:/docker-entrypoint-initdb.d


### PR DESCRIPTION
# 概要

Windowsの一部機種でvolumeのPATH指定に$PWDを入れるとうまく初期データが読み込まれない事象があった。

そもそもこの箇所は絶対パス指定でなく相対パス指定でも問題ないため修正。