### PR TITLE
コマンドの実行と結果を分けて記載

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# デフォルトの無視対象ファイル
+/shelf/
+/workspace.xml

--- a/.idea/docker-mysql-hands-on.iml
+++ b/.idea/docker-mysql-hands-on.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/docker-mysql-hands-on.iml" filepath="$PROJECT_DIR$/.idea/docker-mysql-hands-on.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Windows環境の方はターミナルとしてGit BashやWSL上のターミナ�
 
 ```bash
 % docker -v
+```
+実行結果の例）
+```bash
+% docker -v
 Docker version 20.10.12, build e91ed5707e
 ```
 
@@ -41,11 +45,15 @@ cloneで指定する値は下記のように取得できます。
 
 git cloneを実行するとカレントディレクトリ上に`docker-mysql-hands-on`ディレクトリが作成されているはずです。  
 
+カレントディレクトリ上で下記を実行して確認する。
+```bash
+% ls
+```
+実行結果の例）
 ```bash
 % ls
 docker-mysql-hands-on
 ```
-
 ディレクトリ内に移動して作業を始めましょう。  
 
 ```bash
@@ -73,11 +81,17 @@ docker-mysql-hands-on
 念の為、下記コマンドでdocker-compose.ymlがあることを確認してください。  
 ```bash
 % ls
+```
+実行結果
+```bash
+% ls
 Dockerfile              conf                    renovate.json
 README.md               docker-compose.yml      sql
 ```
-
 コンテナを起動する。  
+```bash
+% docker compose up -d
+```
 ただし初回は時間がかかります。  
 出力内容も下記より多いです。  
 ```bash
@@ -86,8 +100,10 @@ README.md               docker-compose.yml      sql
  ⠿ Network docker-mysql-hands-on_default  Created                                                                                  0.0s
  ⠿ Container docker-mysql-hands-on        Started
 ```
-
 コンテナを確認します。  
+```bash
+% docker ps
+```
 docker-mysql-hands-onがあればOKです。  
 ```bash
 % docker ps           
@@ -95,23 +111,25 @@ CONTAINER ID   IMAGE                      COMMAND                  CREATED      
 850fd542e459   docker-mysql-hands-on_db   "docker-entrypoint.s…"   45 seconds ago   Up 45 seconds   33060/tcp, 0.0.0.0:3307->3306/tcp   docker-mysql-hands-on
 ```
 
-MySQLにログインします。
-パスワードはdocker-compose.ymlに記載されているとおり「password」です。  
-ただし、ターミナルにパスワードを入力するとき、キーボードを叩いても何も表示されませんが心配せず、入力後にエンターキーを押してください。  
-パスワードの入力内容がまったく表示されないのはターミナルを盗み見されても問題がないようにするためです。  
-
+下記を実行しMySQLにログインします。
+```bash
+% docker compose exec db mysql -uroot -p    
+```
+実行結果
 ```bash
 % docker compose exec db mysql -uroot -p    
 Enter password:
 ```
+パスワードはdocker-compose.ymlに記載されているとおり「password」です。  
+ただし、ターミナルにパスワードを入力するとき、キーボードを叩いても何も表示されませんが心配せず、**入力後にエンターキーを押してください。**  
+パスワードの入力内容がまったく表示されないのはターミナルを盗み見されても問題がないようにするためです。  
+
 ※Git Bashの場合、passwordを入力後に動作しないことがあります。
 Windows環境の方は下記コマンドの入力を試してください。
 ```bash
 $ winpty docker compose exec db mysql -uroot -p    
 Enter password:
 ```
-
-
 
 以下のように表示されればMySQLにログインできています。  
 
@@ -133,10 +151,13 @@ Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
 mysql>
 ```
 
-movie_listがあることを確認する。  
-以下の場合、`show databases;`と打ち込んでください。  
+movie_listがあることを確認する。
+```mysql
+mysql> show databases;
+```
 SQL文においてセミコロンはコマンドの終わりを意味していますので入力忘れがないようにしましょう。  
 
+実行結果
 ```mysql
 mysql> show databases;
 +--------------------+
@@ -151,8 +172,12 @@ mysql> show databases;
 5 rows in set (0.03 sec)
 ```
 
-movie_listの利用を開始する。  
+movie_listの利用を開始する。
+```mysql
+mysql> use databases;
+```
 
+実行結果
 ```mysql
 mysql> use movie_list;
 Reading table information for completion of table and column names
@@ -162,7 +187,10 @@ Database changed
 ```
 
 moviesテーブルがあることを確認する。
-
+```mysql
+mysql> show tables;
+```
+実行結果
 ```mysql
 mysql> show tables;
 +----------------------+
@@ -174,7 +202,10 @@ mysql> show tables;
 ```
 
 moviesテーブルのレコードを確認する。
-
+```mysql
+mysql> select * from movies;
+```
+実行結果
 ```mysql
 mysql> select * from movies;
 +----+--------------------------------+-----------------------------+
@@ -187,14 +218,20 @@ mysql> select * from movies;
 ```
 
 テーブルにレコードを追加してみる。
-
+```mysql
+mysql> insert into movies (name, director) values ("ゴッドファーザー", "フランシス・フォード・コッポラ");
+```
+実行結果
 ```mysql
 mysql> insert into movies (name, director) values ("ゴッドファーザー", "フランシス・フォード・コッポラ");
 Query OK, 1 row affected (0.03 sec)
 ```
 
 レコードの登録結果を確認する。
-
+```mysql
+select * from movies;
+```
+実行結果
 ```mysql
 mysql> select * from movies;
 +----+--------------------------------+-----------------------------------------------+
@@ -210,6 +247,10 @@ mysql> select * from movies;
 ログアウトする。  
 ```mysql
 mysql> exit
+```
+実行結果
+```mysql
+mysql> exit
 Bye
 ```
 
@@ -220,6 +261,10 @@ $ docker compose down
 ```
 
 停止できていることを確認する。  
+```bash
+$ docker ps
+```
+実行結果
 ```bash
 % docker ps
 CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES


### PR DESCRIPTION
# 概要
入力するコマンドと実行結果が一緒に記載されており、どこまで入力するのかが分かりづらい部分がありました。
そこでコマンドと結果を分けるような表現に変更してみました。
全体的に変更していますが、例として２箇所の変更を示した画像を添付します。
それぞれ青枠と赤枠が対応しています。

README全体の内容をご確認いただき検討していただければ幸いです。

コミットハッシュ
4d1a55975ed9d9c5b126c3bd4ff5d877e471f6f8

***
### 変更前
<img width="897" alt="スクリーンショット 2023-09-21 14 30 55" src="https://github.com/raisetech-for-student/docker-mysql-hands-on/assets/141313076/27250a99-26c3-4bf7-a948-1e83f88745f4"><br>
***
### 変更後
<img width="729" alt="スクリーンショット 2023-09-21 14 32 31" src="https://github.com/raisetech-for-student/docker-mysql-hands-on/assets/141313076/03a255c4-dac8-41d7-a1fb-b64aa542e232">
